### PR TITLE
Execute one contract in the context of another (support for Upgradable contracts)

### DIFF
--- a/frame/contracts/src/exec.rs
+++ b/frame/contracts/src/exec.rs
@@ -659,11 +659,10 @@ where
 			self.schedule,
 		)?;
 
-		// In order to execute contract in a parent context we need to pass caller account_id
-		// and contract_info to the new frame
 		if preserve_context {
 			frame.account_id = parent_frame.account_id.clone();
 			frame.contract_info = CachedContract::Cached(parent_frame.contract_info().clone());
+			// TODO: handle value transfered, gas and gas_limit
 		}
 
 		self.frames.push(frame);
@@ -1526,7 +1525,7 @@ mod tests {
 		let value = Default::default();
 		let recurse_ch = MockLoader::insert(Call, |ctx, _| {
 			// Try to call into yourself.
-			let r = ctx.ext.call(0, BOB, 0, vec![], true);
+			let r = ctx.ext.call(0, BOB, 0, vec![], true, false);
 
 			REACHED_BOTTOM.with(|reached_bottom| {
 				let mut reached_bottom = reached_bottom.borrow_mut();
@@ -1581,7 +1580,7 @@ mod tests {
 				.with(|caller| *caller.borrow_mut() = Some(ctx.ext.caller().clone()));
 
 			// Call into CHARLIE contract.
-			assert_matches!(ctx.ext.call(0, CHARLIE, 0, vec![], true), Ok(_));
+			assert_matches!(ctx.ext.call(0, CHARLIE, 0, vec![], true, false), Ok(_));
 			exec_success()
 		});
 		let charlie_ch = MockLoader::insert(Call, |ctx, _| {
@@ -1622,7 +1621,7 @@ mod tests {
 			assert_eq!(*ctx.ext.address(), BOB);
 
 			// Call into charlie contract.
-			assert_matches!(ctx.ext.call(0, CHARLIE, 0, vec![], true), Ok(_));
+			assert_matches!(ctx.ext.call(0, CHARLIE, 0, vec![], true, false), Ok(_));
 			exec_success()
 		});
 		let charlie_ch = MockLoader::insert(Call, |ctx, _| {
@@ -1925,13 +1924,13 @@ mod tests {
 				let info = ctx.ext.contract_info();
 				assert_eq!(info.storage_deposit, 0);
 				info.storage_deposit = 42;
-				assert_eq!(ctx.ext.call(0, CHARLIE, 0, vec![], true), exec_trapped());
+				assert_eq!(ctx.ext.call(0, CHARLIE, 0, vec![], true, false), exec_trapped());
 				assert_eq!(ctx.ext.contract_info().storage_deposit, 42);
 			}
 			exec_success()
 		});
 		let code_charlie = MockLoader::insert(Call, |ctx, _| {
-			assert!(ctx.ext.call(0, BOB, 0, vec![99], true).is_ok());
+			assert!(ctx.ext.call(0, BOB, 0, vec![99], true, false).is_ok());
 			exec_trapped()
 		});
 
@@ -1960,7 +1959,7 @@ mod tests {
 	fn recursive_call_during_constructor_fails() {
 		let code = MockLoader::insert(Constructor, |ctx, _| {
 			assert_matches!(
-				ctx.ext.call(0, ctx.ext.address().clone(), 0, vec![], true),
+				ctx.ext.call(0, ctx.ext.address().clone(), 0, vec![], true, false),
 				Err(ExecError{error, ..}) if error == <Error<Test>>::ContractNotFound.into()
 			);
 			exec_success()
@@ -2062,7 +2061,7 @@ mod tests {
 		// call the contract passed as input with disabled reentry
 		let code_bob = MockLoader::insert(Call, |ctx, _| {
 			let dest = Decode::decode(&mut ctx.input_data.as_ref()).unwrap();
-			ctx.ext.call(0, dest, 0, vec![], false)
+			ctx.ext.call(0, dest, 0, vec![], false, false)
 		});
 
 		let code_charlie = MockLoader::insert(Call, |_, _| exec_success());
@@ -2107,7 +2106,7 @@ mod tests {
 	fn call_deny_reentry() {
 		let code_bob = MockLoader::insert(Call, |ctx, _| {
 			if ctx.input_data[0] == 0 {
-				ctx.ext.call(0, CHARLIE, 0, vec![], false)
+				ctx.ext.call(0, CHARLIE, 0, vec![], false, false)
 			} else {
 				exec_success()
 			}
@@ -2115,7 +2114,7 @@ mod tests {
 
 		// call BOB with input set to '1'
 		let code_charlie =
-			MockLoader::insert(Call, |ctx, _| ctx.ext.call(0, BOB, 0, vec![1], true));
+			MockLoader::insert(Call, |ctx, _| ctx.ext.call(0, BOB, 0, vec![1], true, false));
 
 		ExtBuilder::default().build().execute_with(|| {
 			let schedule = <Test as Config>::Schedule::get();
@@ -2138,6 +2137,45 @@ mod tests {
 				.map_err(|e| e.error),
 				<Error<Test>>::ReentranceDenied,
 			);
+		});
+	}
+
+	#[test]
+	fn call_preserve_context() {
+		let code_bob = MockLoader::insert(Call, |ctx, _| {
+			ctx.ext.call(0, CHARLIE, 0, vec![], false, true)?;
+			exec_success()
+		});
+
+		let code_charlie = MockLoader::insert(Call, |ctx, _| {
+			let caller = ctx.ext.caller();
+			let caller_contract_info =
+				<ContractInfoOf<Test>>::get(caller).ok_or(<Error<Test>>::ContractNotFound)?;
+
+			assert_eq!(*caller, BOB);
+			assert_eq!(*ctx.ext.contract_info(), caller_contract_info);
+
+			exec_success()
+		});
+
+		ExtBuilder::default().build().execute_with(|| {
+			let schedule = <Test as Config>::Schedule::get();
+			place_contract(&BOB, code_bob);
+			place_contract(&CHARLIE, code_charlie);
+			let mut storage_meter = storage::meter::Meter::new(&ALICE, Some(0), 0).unwrap();
+
+			let result = MockStack::run_call(
+				ALICE,
+				BOB,
+				&mut GasMeter::<Test>::new(GAS_LIMIT),
+				&mut storage_meter,
+				&schedule,
+				0,
+				vec![0],
+				None,
+			);
+
+			assert_matches!(result, Ok(_));
 		});
 	}
 
@@ -2289,7 +2327,7 @@ mod tests {
 				.unwrap();
 
 			// a plain call should not influence the account counter
-			ctx.ext.call(0, account_id, 0, vec![], false).unwrap();
+			ctx.ext.call(0, account_id, 0, vec![], false, false).unwrap();
 
 			exec_success()
 		});

--- a/frame/contracts/src/exec.rs
+++ b/frame/contracts/src/exec.rs
@@ -662,7 +662,6 @@ where
 		if preserve_context {
 			frame.account_id = parent_frame.account_id.clone();
 			frame.contract_info = CachedContract::Cached(parent_frame.contract_info().clone());
-			// TODO: handle value transfered, gas and gas_limit
 		}
 
 		self.frames.push(frame);
@@ -2154,6 +2153,8 @@ mod tests {
 
 			assert_eq!(*caller, BOB);
 			assert_eq!(*ctx.ext.contract_info(), caller_contract_info);
+			assert_eq!(ctx.ext.value_transferred(), 0u64);
+			assert_eq!(ctx.ext.gas_meter().gas_consumed(), 0u64);
 
 			exec_success()
 		});

--- a/frame/contracts/src/wasm/mod.rs
+++ b/frame/contracts/src/wasm/mod.rs
@@ -350,8 +350,9 @@ mod tests {
 			value: u64,
 			data: Vec<u8>,
 			allows_reentry: bool,
+			preserve_context: bool,
 		) -> Result<ExecReturnValue, ExecError> {
-			self.calls.push(CallEntry { to, value, data, allows_reentry });
+			self.calls.push(CallEntry { to, value, data, allows_reentry, preserve_context });
 			Ok(ExecReturnValue { flags: ReturnFlags::empty(), data: call_return_data() })
 		}
 		fn instantiate(
@@ -552,7 +553,13 @@ mod tests {
 
 		assert_eq!(
 			&mock_ext.calls,
-			&[CallEntry { to: ALICE, value: 6, data: vec![1, 2, 3, 4], allows_reentry: true }]
+			&[CallEntry {
+				to: ALICE,
+				value: 6,
+				data: vec![1, 2, 3, 4],
+				allows_reentry: true,
+				preserve_context: false
+			}]
 		);
 	}
 
@@ -606,7 +613,13 @@ mod tests {
 
 		assert_eq!(
 			&mock_ext.calls,
-			&[CallEntry { to: ALICE, value: 0x2a, data: input, allows_reentry: false }]
+			&[CallEntry {
+				to: ALICE,
+				value: 0x2a,
+				data: input,
+				allows_reentry: false,
+				preserve_context: false
+			}]
 		);
 	}
 
@@ -661,7 +674,13 @@ mod tests {
 		assert_eq!(result.data.0, input);
 		assert_eq!(
 			&mock_ext.calls,
-			&[CallEntry { to: ALICE, value: 0x2a, data: input, allows_reentry: true }]
+			&[CallEntry {
+				to: ALICE,
+				value: 0x2a,
+				data: input,
+				allows_reentry: true,
+				preserve_context: false
+			}]
 		);
 	}
 
@@ -708,7 +727,13 @@ mod tests {
 		assert_eq!(result.data, call_return_data());
 		assert_eq!(
 			&mock_ext.calls,
-			&[CallEntry { to: ALICE, value: 0x2a, data: input, allows_reentry: false }]
+			&[CallEntry {
+				to: ALICE,
+				value: 0x2a,
+				data: input,
+				allows_reentry: false,
+				preserve_context: false
+			}]
 		);
 	}
 
@@ -872,7 +897,13 @@ mod tests {
 
 		assert_eq!(
 			&mock_ext.calls,
-			&[CallEntry { to: ALICE, value: 6, data: vec![1, 2, 3, 4], allows_reentry: true }]
+			&[CallEntry {
+				to: ALICE,
+				value: 6,
+				data: vec![1, 2, 3, 4],
+				allows_reentry: true,
+				preserve_context: false
+			}]
 		);
 	}
 

--- a/frame/contracts/src/wasm/mod.rs
+++ b/frame/contracts/src/wasm/mod.rs
@@ -299,6 +299,7 @@ mod tests {
 		value: u64,
 		data: Vec<u8>,
 		allows_reentry: bool,
+		preserve_context: bool,
 	}
 
 	pub struct MockExt {

--- a/frame/contracts/src/wasm/runtime.rs
+++ b/frame/contracts/src/wasm/runtime.rs
@@ -338,6 +338,11 @@ bitflags! {
 		/// the callee (or any of its callees) is denied. This includes the first callee:
 		/// You cannot call into yourself with this flag set.
 		const ALLOW_REENTRY = 0b0000_1000;
+		/// Allow callee execution in the caller context
+		///
+		/// Provides functionality for creating library smart contract that can be upgraded
+		/// without the need of migrating data
+		const PRESERVE_CONTEXT = 0b0001_0000;
 	}
 }
 
@@ -658,8 +663,14 @@ where
 			self.charge_gas(RuntimeCosts::CallSurchargeTransfer)?;
 		}
 		let ext = &mut self.ext;
-		let call_outcome =
-			ext.call(gas, callee, value, input_data, flags.contains(CallFlags::ALLOW_REENTRY));
+		let call_outcome = ext.call(
+			gas,
+			callee,
+			value,
+			input_data,
+			flags.contains(CallFlags::ALLOW_REENTRY),
+			flags.contains(CallFlags::PRESERVE_CONTEXT),
+		);
 
 		// `TAIL_CALL` only matters on an `OK` result. Otherwise the call stack comes to
 		// a halt anyways without anymore code being executed.

--- a/frame/contracts/src/wasm/runtime.rs
+++ b/frame/contracts/src/wasm/runtime.rs
@@ -17,6 +17,18 @@
 
 //! Environment definition of the wasm smart-contract runtime.
 
+use bitflags::bitflags;
+use codec::{Decode, DecodeAll, Encode, MaxEncodedLen};
+use pwasm_utils::parity_wasm::elements::ValueType;
+
+use frame_support::{dispatch::DispatchError, ensure, weights::Weight};
+use pallet_contracts_primitives::{ExecReturnValue, ReturnFlags};
+use sp_core::{crypto::UncheckedFrom, Bytes};
+use sp_io::hashing::{blake2_128, blake2_256, keccak_256, sha2_256};
+use sp_runtime::traits::{Bounded, Zero};
+use sp_sandbox::SandboxMemory;
+use sp_std::prelude::*;
+
 use crate::{
 	exec::{ExecError, ExecResult, Ext, StorageKey, TopicOf},
 	gas::{ChargedAmount, Token},
@@ -24,16 +36,6 @@ use crate::{
 	wasm::env_def::ConvertibleToWasm,
 	BalanceOf, CodeHash, Config, Error,
 };
-use bitflags::bitflags;
-use codec::{Decode, DecodeAll, Encode, MaxEncodedLen};
-use frame_support::{dispatch::DispatchError, ensure, weights::Weight};
-use pallet_contracts_primitives::{ExecReturnValue, ReturnFlags};
-use pwasm_utils::parity_wasm::elements::ValueType;
-use sp_core::{crypto::UncheckedFrom, Bytes};
-use sp_io::hashing::{blake2_128, blake2_256, keccak_256, sha2_256};
-use sp_runtime::traits::{Bounded, Zero};
-use sp_sandbox::SandboxMemory;
-use sp_std::prelude::*;
 
 /// Every error that can be returned to a contract when it calls any of the host functions.
 ///

--- a/frame/contracts/src/wasm/runtime.rs
+++ b/frame/contracts/src/wasm/runtime.rs
@@ -664,6 +664,10 @@ where
 		if value > 0u32.into() {
 			self.charge_gas(RuntimeCosts::CallSurchargeTransfer)?;
 		}
+
+		let gas = if flags.contains(CallFlags::PRESERVE_CONTEXT) { 0u64.into() } else { gas };
+		let value = if flags.contains(CallFlags::PRESERVE_CONTEXT) { 0u32.into() } else { value };
+
 		let ext = &mut self.ext;
 		let call_outcome = ext.call(
 			gas,


### PR DESCRIPTION
This PR is a follow up to [#7](https://github.com/Supercolony-net/openbrush-contracts/issues/7#issue-915060111) (second reason).

It lets you execute one (callee) contract in the context of another (caller).
Therefore callee contract is a library contract that can be upgraded.

Same logic can be wrapped with a separate api function `seal_delegate_call` (#3)